### PR TITLE
fix/competition-section-data-fetching

### DIFF
--- a/app/how-it-works/page.tsx
+++ b/app/how-it-works/page.tsx
@@ -1,13 +1,12 @@
 'use client';
 
-import { Suspense, memo } from 'react';
+import { Suspense, memo, useState, useCallback } from 'react';
 import Image from 'next/image';
 import { HeroSection } from '@/components/how-it-works/hero-section';
 import { BuildAgentsSection } from '@/components/how-it-works/build-agents-section';
 import { CompetitionSection } from '@/components/how-it-works/competition-section';
 import { UnderHoodSection } from '@/components/how-it-works/under-hood-section';
 import { useAgents } from '@/hooks/use-agents';
-import { useState, useCallback } from 'react';
 
 // Memoize imported components to prevent unnecessary re-renders
 const MemoizedHeroSection = memo(HeroSection);

--- a/app/how-it-works/page.tsx
+++ b/app/how-it-works/page.tsx
@@ -2,11 +2,12 @@
 
 import { Suspense, memo } from 'react';
 import Image from 'next/image';
-import { motion } from 'framer-motion';
 import { HeroSection } from '@/components/how-it-works/hero-section';
 import { BuildAgentsSection } from '@/components/how-it-works/build-agents-section';
 import { CompetitionSection } from '@/components/how-it-works/competition-section';
 import { UnderHoodSection } from '@/components/how-it-works/under-hood-section';
+import { useAgents } from '@/hooks/use-agents';
+import { useState, useCallback } from 'react';
 
 // Memoize imported components to prevent unnecessary re-renders
 const MemoizedHeroSection = memo(HeroSection);
@@ -20,19 +21,31 @@ const SectionFallback = () => (
 );
 
 export default function HowItWorksPage() {
+  const { data: agents, isLoading, error, refetch } = useAgents();
+  const [isRefetching, setIsRefetching] = useState(false);
+
+  const handleRetry = useCallback(async () => {
+    setIsRefetching(true);
+    try {
+      await refetch();
+    } finally {
+      setIsRefetching(false);
+    }
+  }, [refetch]);
+
   return (
     <main className="flex min-h-screen flex-col bg-[#F6ECE7]">
       {/* Background elements - with will-change optimization */}
       <div className="fixed inset-0 bg-gradient-to-br from-orange-500/5 via-transparent to-purple-500/5 pointer-events-none" />
       <div className="glow glow-1 fixed top-0 left-0" />
       <div className="glow glow-2 fixed bottom-0 right-0" />
-      
+
       {/* Background image with optimized loading */}
       <div className="fixed inset-0 z-0 opacity-90 pointer-events-none w-screen">
-        <Image 
-          src="/Group 5749-min.jpg" 
-          alt="Background Pattern" 
-          fill 
+        <Image
+          src="/Group 5749-min.jpg"
+          alt="Background Pattern"
+          fill
           sizes="100vw"
           className="object-cover"
           priority
@@ -45,20 +58,26 @@ export default function HowItWorksPage() {
       <div className="container max-w-7xl mx-auto px-4 py-20 mt-16 relative z-10">
         {/* Hero Section Component - Always render without Suspense since it's above the fold */}
         <MemoizedHeroSection />
-        
+
         {/* Below the fold components wrapped in Suspense for better performance */}
         <Suspense fallback={<SectionFallback />}>
           <MemoizedBuildAgentsSection />
         </Suspense>
-        
+
         <Suspense fallback={<SectionFallback />}>
-          <MemoizedCompetitionSection />
+          <MemoizedCompetitionSection
+            agents={agents}
+            isLoading={isLoading}
+            error={error}
+            isRefetching={isRefetching}
+            handleRetry={handleRetry}
+          />
         </Suspense>
-        
+
         <Suspense fallback={<SectionFallback />}>
           <MemoizedUnderHoodSection />
         </Suspense>
       </div>
     </main>
   );
-} 
+}

--- a/components/how-it-works/competition-section.tsx
+++ b/components/how-it-works/competition-section.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import {  Suspense } from 'react';
+import { Suspense } from 'react';
 import Image from 'next/image';
 import { motion } from 'framer-motion';
 import { TopAgents } from '@/components/top-agents';
@@ -8,7 +8,15 @@ import EmptyState from '@/components/ui/empty-state';
 import { TopAgentsSkeleton } from '@/components/home-skeleton';
 import { Agent } from '@/lib/types';
 
-// Define props
+/**
+ * Props for the CompetitionSection component.
+ *
+ * @property {Agent[] | undefined | null} agents - List of agents to display, or null/undefined if not available.
+ * @property {boolean} isLoading - Indicates whether the data is currently loading.
+ * @property {Error | null} error - Error object if an error occurred, or null if no error.
+ * @property {boolean} isRefetching - Indicates whether data is being refetched.
+ * @property {() => Promise<void>} handleRetry - Function to retry fetching data.
+ */
 type CompetitionSectionProps = {
   agents: Agent[] | undefined | null;
   isLoading: boolean;

--- a/components/how-it-works/competition-section.tsx
+++ b/components/how-it-works/competition-section.tsx
@@ -1,26 +1,29 @@
 'use client';
 
-import { useState, Suspense } from 'react';
+import {  Suspense } from 'react';
 import Image from 'next/image';
 import { motion } from 'framer-motion';
 import { TopAgents } from '@/components/top-agents';
-import { useAgents } from '@/hooks/use-agents';
 import EmptyState from '@/components/ui/empty-state';
 import { TopAgentsSkeleton } from '@/components/home-skeleton';
+import { Agent } from '@/lib/types';
 
-export function CompetitionSection() {
-  const { data: agents, isLoading, error, refetch } = useAgents();
-  const [isRefetching, setIsRefetching] = useState(false);
-  
-  const handleRetry = async () => {
-    setIsRefetching(true);
-    try {
-      await refetch();
-    } finally {
-      setIsRefetching(false);
-    }
-  };
+// Define props
+type CompetitionSectionProps = {
+  agents: Agent[] | undefined | null;
+  isLoading: boolean;
+  error: Error | null;
+  isRefetching: boolean;
+  handleRetry: () => Promise<void>;
+};
 
+export function CompetitionSection({
+  agents,
+  isLoading,
+  error,
+  isRefetching,
+  handleRetry,
+}: CompetitionSectionProps) {
   return (
     <section className="relative mb-20 py-16 px-6 rounded-2xl bg-[#F6ECE7] shadow-sm">
       {/* Section Title */}
@@ -39,22 +42,24 @@ export function CompetitionSection() {
           Left, right, or rekt.
         </p>
         <p className="text-center text-lg mb-0 font-patrick">
-          The most creative and top-performing agents earn<br />
-          from every trade in the protocol. <span className="text-orange-500">🔥</span>
+          The most creative and top-performing agents earn
+          <br />
+          from every trade in the protocol.{' '}
+          <span className="text-orange-500">🔥</span>
         </p>
       </motion.div>
 
       {/* Main Content Grid */}
       <div className="grid grid-cols-1 md:grid-cols-4 gap-4 items-center">
         {/* Left Column - Degen Image (1/4) */}
-        <motion.div 
+        <motion.div
           initial={{ opacity: 0, x: -20 }}
           whileInView={{ opacity: 1, x: 0 }}
           viewport={{ once: true }}
           transition={{ duration: 0.7 }}
           className="md:col-span-1 flex justify-center"
         >
-          <Image 
+          <Image
             src="/hiw/Groupe 6187.png"
             alt="Degen King"
             width={300}
@@ -95,14 +100,14 @@ export function CompetitionSection() {
         </motion.div>
 
         {/* Right Column - Sigma Image (1/4) */}
-        <motion.div 
+        <motion.div
           initial={{ opacity: 0, x: 20 }}
           whileInView={{ opacity: 1, x: 0 }}
           viewport={{ once: true }}
           transition={{ duration: 0.7 }}
           className="md:col-span-1 flex justify-center"
         >
-          <Image 
+          <Image
             src="/hiw/Groupe 5881 lftcrv.png"
             alt="Sigma Lord"
             width={300}
@@ -113,7 +118,7 @@ export function CompetitionSection() {
       </div>
 
       {/* Bottom Text */}
-      <motion.div 
+      <motion.div
         initial={{ opacity: 0 }}
         whileInView={{ opacity: 1 }}
         viewport={{ once: true }}
@@ -124,4 +129,4 @@ export function CompetitionSection() {
       </motion.div>
     </section>
   );
-} 
+}

--- a/components/how-it-works/competition-section.tsx
+++ b/components/how-it-works/competition-section.tsx
@@ -8,15 +8,7 @@ import EmptyState from '@/components/ui/empty-state';
 import { TopAgentsSkeleton } from '@/components/home-skeleton';
 import { Agent } from '@/lib/types';
 
-/**
- * Props for the CompetitionSection component.
- *
- * @property {Agent[] | undefined | null} agents - List of agents to display, or null/undefined if not available.
- * @property {boolean} isLoading - Indicates whether the data is currently loading.
- * @property {Error | null} error - Error object if an error occurred, or null if no error.
- * @property {boolean} isRefetching - Indicates whether data is being refetched.
- * @property {() => Promise<void>} handleRetry - Function to retry fetching data.
- */
+// TypeScript type definitions for the CompetitionSection component props.
 type CompetitionSectionProps = {
   agents: Agent[] | undefined | null;
   isLoading: boolean;


### PR DESCRIPTION
## Fix CompetitionSection Data Fetching Issue

This PR resolves the issue where the `CompetitionSection` component was not reliably loading agent data in the production environment.

### Problem
- `CompetitionSection` was making its own independent API call via `useAgents()` hook
- This pattern worked locally but failed in production
- The same data fetching worked fine on the home page

### Solution
Refactored to match the working home page pattern:

1. **Moved data fetching to page level**: `app/how-it-works/page.tsx` now calls `useAgents()` once
2. **Props-down pattern**: `CompetitionSection` receives agent data as props
3. **Centralized error handling**: Retry logic managed at page level

### Changes
- **`components/how-it-works/competition-section.tsx`**: Removed internal `useAgents()` call, added props interface
- **`app/how-it-works/page.tsx`**: Added `useAgents()` hook and pass data as props

This aligns with the proven working pattern and should resolve the production issue.